### PR TITLE
validator: Hide typesafety part of traceback when run with py.test

### DIFF
--- a/scripts/copyright.py
+++ b/scripts/copyright.py
@@ -21,7 +21,6 @@ import argparse
 import os.path
 import datetime
 import re
-import stat
 import sys
 
 

--- a/typesafety/pytest_typesafety.py
+++ b/typesafety/pytest_typesafety.py
@@ -14,6 +14,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
+from typesafety import TypesafetyError
 
 
 def pytest_addoption(parser):
@@ -40,6 +41,21 @@ def pytest_unconfigure(config):
     if config.getoption('enable_typesafety'):
         import typesafety
         typesafety.deactivate()
+
+
+def pytest_runtest_makereport(item, call):
+    """
+    Use report maker hook for early traceback cleanup
+
+    Have to remove typesafety from trace before py.test removes itself, for
+    avoid empty trace.
+    """
+
+    excinfo = call.excinfo
+    if not excinfo or excinfo.type is not TypesafetyError:
+        return
+
+    excinfo.traceback = excinfo.traceback.filter()
 
 
 def __check_need_activate(module_name, enabled_for):

--- a/typesafety/tests/test_finder.py
+++ b/typesafety/tests/test_finder.py
@@ -15,11 +15,9 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 
-import sys
 import unittest
 
 from typesafety.finder import ModuleFinder
-from typesafety.autodecorator import decorate_module
 
 
 def mock_decorator(func):

--- a/typesafety/tests/test_plugin.py
+++ b/typesafety/tests/test_plugin.py
@@ -19,7 +19,6 @@ import unittest
 import optparse
 import shlex
 import nose
-import mock
 
 from ..noseplugin import TypesafetyPlugin
 

--- a/typesafety/validator.py
+++ b/typesafety/validator.py
@@ -303,4 +303,5 @@ class Validator(object):
         return False
 
 
+__tracebackhide__ = True
 __all__ = ['Validator']


### PR DESCRIPTION
This makes a bit lighter traceback on TypesafetyError.
