### PR TITLE
typing_inspect: validate Union annotation with get_origin

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py36,py35,py34
+envlist=py38,py36,py35,py34
 
 [testenv]
 deps=

--- a/typesafety/tests/test_typing_inspect.py
+++ b/typesafety/tests/test_typing_inspect.py
@@ -23,14 +23,12 @@ from typesafety.typing_inspect import is_union_type, get_union_args
 
 class TestTypingInspect(unittest.TestCase):
     def test_inspect_union_type(self):
-        self.assertTrue(is_union_type(typing.Union))
         self.assertTrue(is_union_type(typing.Union[int, str]))
         self.assertTrue(is_union_type(typing.Optional[int]))
         self.assertFalse(is_union_type(typing.List[int]))
         self.assertFalse(is_union_type(typing.Any))
 
     def test_get_union_args(self):
-        self.assertEqual((), get_union_args(typing.Union))
         self.assertEqual((int, str), get_union_args(typing.Union[int, str]))
         self.assertEqual((int, type(None)), get_union_args(typing.Optional[int]))
         self.assertRaises(TypeError, get_union_args, typing.List[int])

--- a/typesafety/typing_inspect.py
+++ b/typesafety/typing_inspect.py
@@ -35,7 +35,10 @@ def is_union_type(cls):
     if hasattr(typing, '_Union'):
         return type(cls) is typing._Union
 
-    return type(cls) is typing.UnionMeta
+    elif hasattr(typing, 'UnionMeta'):
+        return type(cls) is typing.UnionMeta
+
+    return typing.get_origin(cls) is typing.Union
 
 
 def get_union_args(cls):


### PR DESCRIPTION
The typing module in python 3.8 changed the implementation of `Union`.
`UnionMeta` is no longer part of typing module, but a new function
`get_origin` is added to determine the type of the annotation.

`Union` without arguments are removed from the tests, because they should
be handled as invalid annotation.